### PR TITLE
Remove cfp2016 dep

### DIFF
--- a/2017/package.json
+++ b/2017/package.json
@@ -49,7 +49,7 @@
     "karma-spec-reporter": "0.0.23",
     "karma-typescript-preprocessor": "0.0.21",
     "karma-webpack": "1.7.0",
-    "node-sass": "3.4.2",
+    "node-sass": "4.5.2",
     "phantomjs": "2.1.3",
     "phantomjs-polyfill": "0.0.1",
     "phantomjs-prebuilt": "2.1.3",

--- a/2017/src/modules/bdxio/models/impl/SharedModel.ts
+++ b/2017/src/modules/bdxio/models/impl/SharedModel.ts
@@ -292,8 +292,11 @@ export class SharedModel implements ISharedModel {
             // voxxrinFetched.promise
         ]).then(([_, event, presentations]) => {
             return $q.all([
-                cfpEventModel.buildEvent('BDX I/O 2016', 'https://cfp.bdx.io/api/conferences/BdxIO16', this._data.cfpProgramOptions),
-                cfpEventModel.buildPresentations('https://cfp.bdx.io/api/conferences/BdxIO16', this)
+                // PUT BACK this CFP URLs once CFP 2017 is setup and you don't want to reference 2016 talks anymore
+                // cfpEventModel.buildEvent('BDX I/O 2016', 'https://cfp.bdx.io/api/conferences/BdxIO16', this._data.cfpProgramOptions),
+                // cfpEventModel.buildPresentations('https://cfp.bdx.io/api/conferences/BdxIO16', this)
+                cfpEventModel.buildEvent('BDX I/O 2016', window.location.origin+'/static/prog2016', this._data.cfpProgramOptions),
+                cfpEventModel.buildPresentations(window.location.origin+'/static/prog2016', this)
             ]);
         }, rejectDeferred(this._dataLoadedDefer, "Error while fetching data"))
         .then(([event, presentations]) => {


### PR DESCRIPTION
This will allow to reset CFP content and keep 2016 schedule content.

Note that :
- I had to upgrade `node-sass` to latest version since, with my current node version (7.5.0), `npm start` was not working
- I didn't removed all the CFP dependency, looking at network XHR, I still have some calls to the CFP for 2 speakers which seem to miss in the initial listing (dunno why, there might be a bug in the CFP)
<img width="574" alt="pasted_image_13_05_17_22_52" src="https://cloud.githubusercontent.com/assets/603815/26029166/fe4bcf00-382e-11e7-9b91-1381044357ea.png">
