### PR TITLE
chore: add openfeedback route 

### DIFF
--- a/api/src/api/openfeedback/controllers/openfeedback.js
+++ b/api/src/api/openfeedback/controllers/openfeedback.js
@@ -6,7 +6,7 @@ module.exports = {
     try {
       const sessionsAndSpeakers = await getSessionsAndSpeakers();
       ctx.status = 200;
-      ctx.body = sessionsAndSpeakers;
+      ctx.body = { sessions: sessionsAndSpeakers };
     } catch (e) {
       ctx.status = 500;
       console.error(e);
@@ -16,41 +16,3 @@ module.exports = {
     }
   },
 };
-
-// {
-//   "sessions": {
-//       "2": {
-//           "speakers": [
-//               "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
-//           ],
-//           "tags": [
-//               "Architecture & Paradigme"
-//           ],
-//           "title": "Entre industrialisation et artisanat, le métier de développeur",
-//           "id": "2",
-//           "startTime": "2019-06-27T16:20:00+02:00",
-//           "endTime": "2019-06-27T17:10:00+02:00",
-//           "trackTitle": "Amphi D"
-//       },
-//       "30": {
-//           "...": "",
-//           "hideInFeedback": true
-//       }
-//   },
-//   "speakers": {
-//       "lhwORZ2dSGbF1OG6VkfbjkOCzR12": {
-//           "name": "Olivier PONCET",
-//           "photoUrl": "https://avatars2.githubusercontent.com/u/29702924?v=4",
-//           "socials": [
-//               {
-//                   "name": "twitter",
-//                   "link": "https://twitter.com/ponceto91"
-//               }
-//           ],
-//           "id": "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
-//       },
-//       "anotherId": {
-//           "...": ""
-//       }
-//   }
-// }

--- a/api/src/api/openfeedback/controllers/openfeedback.js
+++ b/api/src/api/openfeedback/controllers/openfeedback.js
@@ -1,0 +1,59 @@
+"use strict";
+const { getSessions, getSpeakers } = require("../../../helpers");
+
+module.exports = {
+  async getOpenfeedbackFormattedData(ctx, next) {
+    try {
+      const [sessions, speakers] = await Promise.all([
+        getSessions(),
+        getSpeakers(),
+      ]);
+      ctx.status = 200;
+      ctx.body = { sessions, speakers };
+    } catch (e) {
+      ctx.status = 500;
+      console.error(e);
+      ctx.body = e;
+    } finally {
+      next();
+    }
+  },
+};
+
+// {
+//   "sessions": {
+//       "2": {
+//           "speakers": [
+//               "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
+//           ],
+//           "tags": [
+//               "Architecture & Paradigme"
+//           ],
+//           "title": "Entre industrialisation et artisanat, le métier de développeur",
+//           "id": "2",
+//           "startTime": "2019-06-27T16:20:00+02:00",
+//           "endTime": "2019-06-27T17:10:00+02:00",
+//           "trackTitle": "Amphi D"
+//       },
+//       "30": {
+//           "...": "",
+//           "hideInFeedback": true
+//       }
+//   },
+//   "speakers": {
+//       "lhwORZ2dSGbF1OG6VkfbjkOCzR12": {
+//           "name": "Olivier PONCET",
+//           "photoUrl": "https://avatars2.githubusercontent.com/u/29702924?v=4",
+//           "socials": [
+//               {
+//                   "name": "twitter",
+//                   "link": "https://twitter.com/ponceto91"
+//               }
+//           ],
+//           "id": "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
+//       },
+//       "anotherId": {
+//           "...": ""
+//       }
+//   }
+// }

--- a/api/src/api/openfeedback/controllers/openfeedback.js
+++ b/api/src/api/openfeedback/controllers/openfeedback.js
@@ -1,15 +1,12 @@
 "use strict";
-const { getSessions, getSpeakers } = require("../../../helpers");
+const { getSessionsAndSpeakers } = require("../../../helpers");
 
 module.exports = {
   async getOpenfeedbackFormattedData(ctx, next) {
     try {
-      const [sessions, speakers] = await Promise.all([
-        getSessions(),
-        getSpeakers(),
-      ]);
+      const sessionsAndSpeakers = await getSessionsAndSpeakers();
       ctx.status = 200;
-      ctx.body = { sessions, speakers };
+      ctx.body = sessionsAndSpeakers;
     } catch (e) {
       ctx.status = 500;
       console.error(e);

--- a/api/src/api/openfeedback/routes/openfeedback.js
+++ b/api/src/api/openfeedback/routes/openfeedback.js
@@ -1,0 +1,12 @@
+module.exports = {
+  routes: [
+    {
+      method: "GET",
+      path: "/openfeedback",
+      handler: "openfeedback.getOpenfeedbackFormattedData",
+      config: {
+        auth: { scope: ["find"] },
+      },
+    },
+  ],
+};

--- a/api/src/helpers/database.js
+++ b/api/src/helpers/database.js
@@ -1,3 +1,16 @@
+async function findAll(collection) {
+  try {
+    const result = await strapi.db
+      .query(collection)
+      .findMany({ populate: true });
+
+    return result;
+  } catch (error) {
+    console.error(`Error while finding ${collection}: ${error}`);
+    return;
+  }
+}
+
 async function findItemInTable(collection, query) {
   try {
     const result = await strapi.db.query(collection).findOne(query);
@@ -45,6 +58,7 @@ async function populateItemInTable(collection, data) {
 
 module.exports = {
   findItemInTable,
+  findAll,
   populateItemInTable,
   publishItemInTable,
   deleteTable,

--- a/api/src/helpers/database.js
+++ b/api/src/helpers/database.js
@@ -1,8 +1,8 @@
-async function findAll(collection) {
+async function findAll(collection, populate) {
   try {
     const result = await strapi.db
       .query(collection)
-      .findMany({ populate: true });
+      .findMany(populate ? { populate } : { populate: true });
 
     return result;
   } catch (error) {

--- a/api/src/helpers/index.js
+++ b/api/src/helpers/index.js
@@ -1,4 +1,9 @@
 const populateHelpers = require("./populate");
 const databaseHelpers = require("./database");
+const openfeedbackHelpers = require("./openfeedback");
 
-module.exports = { ...databaseHelpers, ...populateHelpers };
+module.exports = {
+  ...databaseHelpers,
+  ...populateHelpers,
+  ...openfeedbackHelpers,
+};

--- a/api/src/helpers/openfeedback/getSessions.js
+++ b/api/src/helpers/openfeedback/getSessions.js
@@ -1,0 +1,32 @@
+const { findAll } = require("../../helpers/database");
+
+async function getSessions() {
+  const resource = "api::slot.slot";
+  const allSessions = await findAll(resource);
+
+  const allTalksSessions = allSessions.filter(
+    (sessions) => sessions.talks.length > 0
+  );
+  console.log("All sessions: ", allSessions);
+
+  return allTalksSessions.reduce((formattedSessions, session) => {
+    const { startSlot, endSlot, talks, rooms } = session;
+    console.log("talks", talks);
+
+    talks.forEach((talk) => {
+      formattedSessions[talk.id] = {
+        speakers: "test",
+        tags: [],
+        title: talk.title,
+        id: talk.id,
+        startTime: startSlot,
+        endTime: endSlot,
+        trackTitle: rooms.length ? rooms[0].name : undefined,
+      };
+    });
+
+    return formattedSessions;
+  }, {});
+}
+
+module.exports = getSessions;

--- a/api/src/helpers/openfeedback/getSpeakers.js
+++ b/api/src/helpers/openfeedback/getSpeakers.js
@@ -1,0 +1,35 @@
+const { findAll } = require("../../helpers/database");
+
+async function getSpeakers() {
+  const resource = "api::speaker.speaker";
+  const speakers = await findAll(resource);
+
+  return speakers.reduce((formattedSpeakers, speaker) => {
+    const { conferenceHallId: id, name, photoUrl, twitter, github } = speaker;
+
+    formattedSpeakers[id] = {
+      name,
+      id,
+      photoUrl,
+      socials: [],
+    };
+
+    if (twitter) {
+      formattedSpeakers[id].socials["twitter"] = {
+        name: "twitter",
+        link: `https://twitter.com/${twitter}`,
+      };
+    }
+
+    if (github) {
+      formattedSpeakers[id].socials["github"] = {
+        name: "github",
+        link: `https://github.com/${github}`,
+      };
+    }
+
+    return formattedSpeakers;
+  }, {});
+}
+
+module.exports = getSpeakers;

--- a/api/src/helpers/openfeedback/getSpeakers.js
+++ b/api/src/helpers/openfeedback/getSpeakers.js
@@ -1,35 +1,28 @@
-const { findAll } = require("../../helpers/database");
+function formatSpeakerData(speaker) {
+  const { conferenceHallId: id, name, photoUrl, twitter, github } = speaker;
 
-async function getSpeakers() {
-  const resource = "api::speaker.speaker";
-  const speakers = await findAll(resource);
+  const formattedSpeaker = {
+    name,
+    id,
+    photoUrl,
+    socials: [],
+  };
 
-  return speakers.reduce((formattedSpeakers, speaker) => {
-    const { conferenceHallId: id, name, photoUrl, twitter, github } = speaker;
-
-    formattedSpeakers[id] = {
-      name,
-      id,
-      photoUrl,
-      socials: [],
+  if (twitter) {
+    formattedSpeaker.socials["twitter"] = {
+      name: "twitter",
+      link: `https://twitter.com/${twitter}`,
     };
+  }
 
-    if (twitter) {
-      formattedSpeakers[id].socials["twitter"] = {
-        name: "twitter",
-        link: `https://twitter.com/${twitter}`,
-      };
-    }
+  if (github) {
+    formattedSpeaker.socials["github"] = {
+      name: "github",
+      link: `https://github.com/${github}`,
+    };
+  }
 
-    if (github) {
-      formattedSpeakers[id].socials["github"] = {
-        name: "github",
-        link: `https://github.com/${github}`,
-      };
-    }
-
-    return formattedSpeakers;
-  }, {});
+  return formattedSpeaker;
 }
 
-module.exports = getSpeakers;
+module.exports = { formatSpeakerData };

--- a/api/src/helpers/openfeedback/index.js
+++ b/api/src/helpers/openfeedback/index.js
@@ -1,7 +1,3 @@
-const getSpeakers = require("./getSpeakers");
-const getSessions = require("./getSessions");
+const getSessionsAndSpeakers = require("./getSessions");
 
-module.exports = {
-  getSpeakers,
-  getSessions,
-};
+module.exports = { getSessionsAndSpeakers };

--- a/api/src/helpers/openfeedback/index.js
+++ b/api/src/helpers/openfeedback/index.js
@@ -1,0 +1,7 @@
+const getSpeakers = require("./getSpeakers");
+const getSessions = require("./getSessions");
+
+module.exports = {
+  getSpeakers,
+  getSessions,
+};

--- a/api/src/helpers/populate/index.js
+++ b/api/src/helpers/populate/index.js
@@ -13,5 +13,5 @@ module.exports = {
   populateSpeakerTable,
   populateTalkTable,
   populateRoomTable,
-  populateSlotTable
+  populateSlotTable,
 };

--- a/api/src/helpers/populate/resources/speaker.js
+++ b/api/src/helpers/populate/resources/speaker.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require("axios").default;
 
 const {
   deleteTable,
@@ -11,7 +11,10 @@ async function isValidSpeakerPicture(speakerUrl) {
     return false;
   }
 
-  return await axios.get(speakerUrl).then(response => response.status === 200).catch(() => false)
+  return await axios
+    .get(speakerUrl)
+    .then((response) => response.status === 200)
+    .catch(() => false);
 }
 
 async function populateSpeakerTable(speakers) {
@@ -30,12 +33,14 @@ async function populateSpeakerTable(speakers) {
       name: speaker.displayName || "",
       bio: speaker.bio && speaker.bio.length ? speaker.bio.trim() : "",
       address: speaker.address || "",
-      photoUrl: await isValidSpeakerPicture(speaker.photoURL) ? speaker.photoURL : "",
+      photoUrl: (await isValidSpeakerPicture(speaker.photoURL))
+        ? speaker.photoURL
+        : "",
       twitter: speaker.twitter || "",
       github: speaker.github || "",
       company: speaker.company || "",
     });
-    
+
     await publishItemInTable(resource, id);
   }
   console.log("speakers have been added into database");


### PR DESCRIPTION
Add a route that retrieves the talk sessions and return a valid output, ready to be consumed by OpenFeedback.

Output format: 
```json
{
  "sessions": {
      "2": {
          "speakers": [
              "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
          ],
          "tags": [
              "Architecture & Paradigme"
          ],
          "title": "Entre industrialisation et artisanat, le métier de développeur",
          "id": "2",
          "startTime": "2019-06-27T16:20:00+02:00",
          "endTime": "2019-06-27T17:10:00+02:00",
          "trackTitle": "Amphi D"
      },
      "30": {
          "...": "",
          "hideInFeedback": true
      }
  },
  "speakers": {
      "lhwORZ2dSGbF1OG6VkfbjkOCzR12": {
          "name": "Olivier PONCET",
          "photoUrl": "https://avatars2.githubusercontent.com/u/29702924?v=4",
          "socials": [
              {
                  "name": "twitter",
                  "link": "https://twitter.com/ponceto91"
              }
          ],
          "id": "lhwORZ2dSGbF1OG6VkfbjkOCzR12"
      },
      "anotherId": {
          "...": ""
      }
  }
}
```